### PR TITLE
Some fixes

### DIFF
--- a/plugin/src/baas.cpp
+++ b/plugin/src/baas.cpp
@@ -8,8 +8,8 @@
 */
 
 /* -------------------- Constructor and destructor ----------------------------------*/
-BaaS::BaaS(QObject *parent) :
-    QObject(parent)
+BaaS::BaaS() :
+    QObject()
 {
     _NAM = new QNetworkAccessManager(this);
 

--- a/plugin/src/baas.cpp
+++ b/plugin/src/baas.cpp
@@ -170,12 +170,12 @@ QNetworkReply* BaaS::processRequest( BaaS::Operation operation, const QUrl& url 
         buffer->close();
         break;
     }
-    return reply;
 
     //Empty the header
     resetHeaders();
     resetRawHeaders();
 
+    return reply;
 }
 
 QNetworkReply* BaaS::request( BaaS::Operation operation, const QByteArray& data )

--- a/plugin/src/baas.h
+++ b/plugin/src/baas.h
@@ -28,7 +28,7 @@ class BaaS : public QObject
 
 public:
 
-    explicit BaaS(QObject *parent = 0);
+    explicit BaaS();
     virtual ~BaaS();
 
     enum Operation{ GET, POST, PUT, DELETE, PATCH};

--- a/plugin/src/baasmodel.h
+++ b/plugin/src/baasmodel.h
@@ -119,8 +119,8 @@ private:
     BaaS* backend = nullptr;
 
 
-    QVector<BaaSModelItem> rows = QVector<BaaSModelItem>();
-    QHash<int, QByteArray> roles = QHash<int, QByteArray>();
+    QVector<BaaSModelItem> rows;
+    QHash<int, QByteArray> roles;
 
     QString endPoint = "";
     QString where = "";


### PR DESCRIPTION
I'm not sure if the `= QVector<BaaSModelItem>()` and `= QHash<int, QByteArray>()` assignment are adding something (more) really, what do you think ? GCC 4.9 chokes on them, anyway.
