### PR TITLE
Allow to configure URI suffix

### DIFF
--- a/plugin/src/baas.cpp
+++ b/plugin/src/baas.cpp
@@ -22,17 +22,29 @@ BaaS::~BaaS()
 
 
 /* -------------------- Property accessors ----------------------------------*/
+
 void BaaS::setHostURI(const QString& res){
     if (hostURI!= res){
         hostURI = res;
         emit hostChanged();
         emit readyChanged();
     }
-
 }
 QString BaaS::getHostURI() const{
     return hostURI;
 }
+
+void BaaS::setExtraHostURI(const QString& res){
+    if (extraHostURI!= res){
+        extraHostURI = res;
+        emit hostChanged();
+        emit readyChanged();
+    }
+}
+QString BaaS::getExtraHostURI() const{
+    return extraHostURI;
+}
+
 void BaaS::setError(const QString& res){
     error = res;
     emit errorChanged();

--- a/plugin/src/baas.h
+++ b/plugin/src/baas.h
@@ -18,6 +18,7 @@ class BaaS : public QObject
 {
     Q_OBJECT
     Q_PROPERTY( QString hostURI READ getHostURI  WRITE setHostURI NOTIFY hostChanged)
+    Q_PROPERTY( QString extraHostURI READ getExtraHostURI  WRITE setExtraHostURI NOTIFY hostChanged)
     Q_PROPERTY( QString endPoint READ getEndPoint WRITE setEndPoint NOTIFY endPointChanged)
     Q_PROPERTY( QString error READ getError WRITE setError NOTIFY errorChanged)
     Q_PROPERTY( qreal percComplete READ getPercComplete WRITE setPercComplete NOTIFY percCompleteChanged)
@@ -38,6 +39,8 @@ public:
 public: // property access
     QString getHostURI() const;
     void setHostURI(const QString& res);
+    QString getExtraHostURI() const;
+    void setExtraHostURI(const QString& res);
     QString getError() const;
     void setError(const QString& res);
     QString getEndPoint() const;
@@ -70,8 +73,7 @@ protected:
     void initHeaders( ){}
     void applyAllHeaders( QNetworkRequest&) const;
 
-    // setExtraHostURI to define Parse server version and/or mount point
-    void setExtraHostURI(QString res){ extraHostURI = res;}
+    void setDefaultExtraHostURI(QString res){ extraHostURI = res;}
     bool isLastRequestSuccessful()const{ return lastRequestSuccessful;}
 
 

--- a/plugin/src/parse.cpp
+++ b/plugin/src/parse.cpp
@@ -5,11 +5,8 @@
 
 Parse::Parse(): BaaS()
 {
-
     //Defines default headers
-    setExtraHostURI("parse");
-
-
+    setDefaultExtraHostURI("parse");
 }
 
 void Parse::initHeaders( )


### PR DESCRIPTION
For Parse Server, "parse" is only the default URI suffix.
