### PR TITLE
Add query arg to reply finished / succeeded

### DIFF
--- a/plugin/src/baas.cpp
+++ b/plugin/src/baas.cpp
@@ -126,7 +126,7 @@ void BaaS::replyError(QNetworkReply::NetworkError)
     setHttpCode( reply->error() );
     setError(reply->errorString());
     qDebug() << "REPLY ERROR" << reply->errorString();
-
+    emit queryFailed(getError());
 }
 
 void BaaS::replyProgress(qint64 bytesSent, qint64 bytesTotal)

--- a/plugin/src/baas.cpp
+++ b/plugin/src/baas.cpp
@@ -115,7 +115,7 @@ void BaaS::readReply( QNetworkReply *reply )
         reply->deleteLater();
     }
     //qDebug() << "REPLYFINISHED" << json;
-    emit replyFinished(json);
+    emit replyFinished(json, reply);
 }
 
 

--- a/plugin/src/baas.h
+++ b/plugin/src/baas.h
@@ -85,8 +85,8 @@ signals: // operation notifications
     void httpCodeChanged();
     void httpResponseChanged();
     void replyFinished(QJsonDocument doc, QNetworkReply *reply);                       //emited when a request gets replied
-    void queryFailed(QJsonDocument doc);
-    void querySucceeded(QHash<int, QByteArray> roles, QVector<QVariantMap> data);
+    void queryFailed(QString msg);
+    void querySucceeded(QHash<int, QByteArray> roles, QVector<QVariantMap> data, QNetworkReply *reply);
     void readyChanged();
 
 private:

--- a/plugin/src/baas.h
+++ b/plugin/src/baas.h
@@ -84,7 +84,7 @@ signals: // operation notifications
     void percCompleteChanged();
     void httpCodeChanged();
     void httpResponseChanged();
-    void replyFinished( QJsonDocument doc);                       //emited when a request gets replied
+    void replyFinished(QJsonDocument doc, QNetworkReply *reply);                       //emited when a request gets replied
     void queryFailed(QJsonDocument doc);
     void querySucceeded(QHash<int, QByteArray> roles, QVector<QVariantMap> data);
     void readyChanged();

--- a/plugin/src/baasmodel.cpp
+++ b/plugin/src/baasmodel.cpp
@@ -61,14 +61,14 @@ void BaaSModel::setBackend(BaaS* be){
     }
 }
 
-void BaaSModel::onQueryFailed(QJsonDocument json)
+void BaaSModel::onQueryFailed(QString msg)
 {
     beginResetModel();
     rows.clear();
     roles.clear();
     endResetModel();
     emit queryDone();
-    qDebug() << json.toJson();
+    qDebug() << msg;
 }
 
 void BaaSModel::onQuerySucceeded(QHash<int, QByteArray> _roles, QVector<QVariantMap> _data)

--- a/plugin/src/baasmodel.h
+++ b/plugin/src/baasmodel.h
@@ -104,7 +104,7 @@ public:
     }
 
 private slots:
-    void onQueryFailed(QJsonDocument json);
+    void onQueryFailed(QString msg);
     void onQuerySucceeded(QHash<int, QByteArray> roles, QVector<QVariantMap> data);
 
 signals:

--- a/plugin/src/parse.cpp
+++ b/plugin/src/parse.cpp
@@ -219,9 +219,7 @@ QNetworkReply *Parse::query(QString endPoint, QUrlQuery extraParams)
                     data.push_back( obj.toVariantMap());
                     emit querySucceeded(roles, data, reply);
                 }
-            }
-            else emit queryFailed(getError());
-
+        }
     } );
 
     initHeaders();

--- a/plugin/src/parse.cpp
+++ b/plugin/src/parse.cpp
@@ -168,11 +168,12 @@ QNetworkReply *Parse::query(QString endPoint, QUrlQuery extraParams)
     if (!isReady()) return NULL;
 
     if (extraParams.isEmpty())
-        setEndPoint( endPoint);
+        setEndPoint(endPoint);
     else setEndPoint( endPoint + "?" + extraParams.toString() ); //TODO improve me : not use endpoint to give url encoded params
 
+    ensureEndPointHasPrefix("classes");
 
-    m_conn = connect(this, &BaaS::replyFinished, [=]( QJsonDocument json){
+    m_conn = connect(this, &BaaS::replyFinished, [=](QJsonDocument json, QNetworkReply *reply){
         disconnect(m_conn);
         if (isLastRequestSuccessful()){
                 //structure to return from parse
@@ -203,7 +204,7 @@ QNetworkReply *Parse::query(QString endPoint, QUrlQuery extraParams)
                         }
                     }
 
-                    emit querySucceeded(roles, data);
+                    emit querySucceeded(roles, data, reply);
                 }
                 //else if (tmp.isObject()){
                     //obj = tmp.toObject();//Update roles
@@ -216,10 +217,10 @@ QNetworkReply *Parse::query(QString endPoint, QUrlQuery extraParams)
                     }
                     //Add values
                     data.push_back( obj.toVariantMap());
-                    emit querySucceeded(roles, data);
+                    emit querySucceeded(roles, data, reply);
                 }
             }
-            else emit queryFailed(json);
+            else emit queryFailed(getError());
 
     } );
 


### PR DESCRIPTION
- error message in queryFailed
- add "classes" prefix in Parse query
